### PR TITLE
Add support for array of actions in useAppCanWrapper methods and upda…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versi
 
 ## Não publicado
 ### Adicionado
-`useAppCanWrapper`:
-  - adicionado opção `action` nos métodos `can` e `canByPermission` para receber `string` ou `string[]` (array de string), anteriormente só recebia string, agora pode passar uma lista de ações.
-  - modificado testes unitários para aceitar mudanças no `action`.
+`useAppCanWrapper`: adicionado opção `action` nos métodos `can` e `canByPermission` para receber `string` ou `string[]` (array de string), anteriormente só recebia string, agora pode passar uma lista de ações.
 
 ## 1.0.0-beta.9 - 05-12-2024
 ### Adicionado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
+## Não publicado
+### Adicionado
+`useAppCanWrapper`:
+  - adicionado opção `action` nos métodos `can` e `canByPermission` para receber `string` ou `string[]` (array de string), anteriormente só recebia string, agora pode passar uma lista de ações.
+  - modificado testes unitários para aceitar mudanças no `action`.
+
 ## 1.0.0-beta.9 - 05-12-2024
 ### Adicionado
 - `useView`: adicionado nova função `reset` para resetar todos valores do view.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ const {
 } = useAppCan({ store })
 
 can('users', { action: 'dashboard' })
+can('users', { action: ['dashboard', 'show'] })
 can({ users: { action: 'dashboard' } })
+can({ users: { action: ['dashboard', 'show'] } })
 
 canList('users')
 canList(['users', 'approvals'])
@@ -95,7 +97,9 @@ canCreate('users')
 canCreate(['users', 'approvals'])
 
 canByPermission('users', { company: 'company1', action: 'dashboard' })
+canByPermission('users', { company: 'company1', action: ['dashboard', 'list'] })
 canByPermission({ users: { company: ['company1', 'company2'], action: 'dashboard' } })
+canByPermission({ users: { company: ['company1', 'company2'], action: ['dashboard', 'list'] } })
 
 canEdit('users', { company: ['company1', 'company2'] })
 canEdit({ users: { company: 'company1' } })

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
@@ -61,8 +61,12 @@ describe.each(storeList)('Permissionamento -> isSuperuser: $isSuperuser', (store
     expect(can('settings', { action: 'dashboard' })).toBe(isSuperuser)
     expect(can('settings', { action: '' })).toBe(isSuperuser)
     expect(can('settings', { action: 'create' })).toBe(true)
+    expect(can('users', { action: ['list', 'waitingCompanyLinks', 'approvals'] })).toBe(true)
+    expect(can('settings', { action: ['list', 'waitingCompanyLinks', 'approvals'] })).toBe(isSuperuser)
     expect(can({ users: { action: 'create' }, settings: { action: 'create' } })).toBe(true)
     expect(can({ users: { action: 'create' }, companies: { action: 'create' } })).toBe(isSuperuser)
+    expect(can({ users: { action: ['show', 'xpto2'] }, companies: { action: 'xpto2' } })).toBe(true)
+    expect(can({ users: { action: ['xpto1', 'xpto2'] }, companies: { action: 'xpto2' } })).toBe(isSuperuser)
   })
 
   it(`canList -> isSuperUser: ${isSuperuser}`, () => {
@@ -92,10 +96,13 @@ describe.each(storeList)('Permissionamento -> isSuperuser: $isSuperuser', (store
     expect(canByPermission({ users: { action: 'edit', company: ['company-uuid03'] } })).toBe(true)
     expect(canByPermission({ users: { action: 'edit', company: 'company-uuid03' } })).toBe(true)
 
+    expect(canByPermission({ users: { action: ['edit', 'xpto'], company: 'company-uuid03' } })).toBe(true)
+    expect(canByPermission({ users: { action: ['edit', 'xpto'], company: 'company-uuid032' } })).toBe(isSuperuser)
+
     expect(canByPermission(
       {
         users: {
-          action: 'edit',
+          action: ['edit', 'xpto'],
           company: 'company-uuid03'
         },
         settings: {

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
@@ -66,6 +66,7 @@ describe.each(storeList)('Permissionamento -> isSuperuser: $isSuperuser', (store
     expect(can({ users: { action: 'create' }, settings: { action: 'create' } })).toBe(true)
     expect(can({ users: { action: 'create' }, companies: { action: 'create' } })).toBe(isSuperuser)
     expect(can({ users: { action: ['show', 'xpto2'] }, companies: { action: 'xpto2' } })).toBe(true)
+    expect(can({ users: { action: ['show', 'edit'] }, companies: { action: 'create' } })).toBe(true)
     expect(can({ users: { action: ['xpto1', 'xpto2'] }, companies: { action: 'xpto2' } })).toBe(isSuperuser)
   })
 

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.ts
@@ -28,7 +28,9 @@ import {
  * } = useAppCanWrapper({ store })
  *
  * can('users', { action: 'dashboard' })
+ * can('users', { action: ['dashboard', 'show'] })
  * can({ users: { action: 'dashboard' } })
+ * can({ users: { action: ['dashboard', 'show'] } })
  *
  * canList('users')
  * canList(['users', 'approvals'])
@@ -37,7 +39,9 @@ import {
  * canCreate(['users', 'approvals'])
  *
  * canByPermission('users', { company: 'company1', action: 'dashboard' })
+ * canByPermission('users', { company: 'company1', action: ['dashboard', 'list'] })
  * canByPermission({ users: { company: ['company1', 'company2'], action: 'dashboard' } })
+ * canByPermission({ users: { company: ['company1', 'company2'], action: ['dashboard', 'list'] } })
  *
  * canEdit('users', { company: ['company1', 'company2'] })
  * canEdit({ users: { company: 'company1' } })
@@ -72,13 +76,22 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
     for (const entity in normalizedParamsPayload) {
       const { action } = normalizedParamsPayload[entity]
 
+      /**
+       * @example action: ['list', 'show']
+       */
+      const normalizedAction = Array.isArray(action) ? action : [action]
+
       for (const companyKey in companyPermissions) {
         /**
          * @example permissionItem: ['companies.list', 'companies.show']
          */
         const permissionItem = companyPermissions[companyKey]
 
-        if (permissionItem.includes(`${entity}.${action}`)) return true
+        const hasInPermissionItem = normalizedAction.some(actionItem => {
+          return permissionItem.includes(`${entity}.${actionItem}`)
+        })
+
+        if (hasInPermissionItem) return true
       }
     }
 
@@ -129,6 +142,11 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
       const normalizedCompany = Array.isArray(company) ? company : [company]
 
       /**
+       * @example action: ['list', 'show']
+       */
+      const normalizedAction = Array.isArray(action) ? action : [action]
+
+      /**
        * @example normalizedCompany: ['company1', 'company2']
        */
       for (const companyItem of normalizedCompany) {
@@ -146,7 +164,11 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
           ...(companyPermission || [])
         ]
 
-        if (permissionItem.includes(`${entity}.${action}`)) return true
+        const hasInPermissionItem = normalizedAction.some(actionItem => {
+          return permissionItem.includes(`${entity}.${actionItem}`)
+        })
+
+        if (hasInPermissionItem) return true
       }
     }
 

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.ts
@@ -9,7 +9,8 @@ import {
 import {
   getNormalizedParams,
   getNormalizedParamsByPermission,
-  getNormalizedParamsPayload
+  getNormalizedParamsPayload,
+  hasPermission
 } from './use-app-can-wrapper.util'
 
 /**
@@ -87,11 +88,7 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
          */
         const permissionItem = companyPermissions[companyKey]
 
-        const hasInPermissionItem = normalizedAction.some(actionItem => {
-          return permissionItem.includes(`${entity}.${actionItem}`)
-        })
-
-        if (hasInPermissionItem) return true
+        if (hasPermission(normalizedAction, entity, permissionItem)) return true
       }
     }
 
@@ -164,11 +161,7 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
           ...(companyPermission || [])
         ]
 
-        const hasInPermissionItem = normalizedAction.some(actionItem => {
-          return permissionItem.includes(`${entity}.${actionItem}`)
-        })
-
-        if (hasInPermissionItem) return true
+        if (hasPermission(normalizedAction, entity, permissionItem)) return true
       }
     }
 

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.type.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.type.ts
@@ -4,12 +4,14 @@ export type AppCanStoreOptions = 'isSuperuser' | 'companyPermissions' | 'current
 
 export type AppCanWrapperStore = Required<Pick<UserStore, AppCanStoreOptions>>
 
+export type ActionType = string | string[]
+
 export type UseAppCanWrapperParam = {
   store: AppCanWrapperStore
 }
 
 export type CanConfig = {
-  action: string
+  action: ActionType
 }
 
 export type StringOrStringList = string | string[]
@@ -25,7 +27,7 @@ export type CanByPermission = (entityConfig: CanByPermissionEntityConfig, config
 
 export type CanByPermissionConfig = {
   company: StringOrStringList
-  action: string
+  action: ActionType
 }
 
 export type CanByPermissionEditConfig = Pick<CanByPermissionConfig, 'company'>
@@ -42,10 +44,10 @@ export type CanByPermissionWrapperFunction = (
 ) => boolean
 
 export type GetNormalizedParamsByPermission = (
-  action: string,
+  action: ActionType,
   entityConfig: CanByPermissionEntityEditConfig,
   config?: CanByPermissionEditConfig
 ) => CanByPermissionObjectOfConfig
 
-export type GetNormalizedParams = (action: string, entity: StringOrStringList) => CanObjectOfConfig
+export type GetNormalizedParams = (action: ActionType, entity: StringOrStringList) => CanObjectOfConfig
 export type CanWrapperFunction = (entity: StringOrStringList) => boolean

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.type.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.type.ts
@@ -51,3 +51,4 @@ export type GetNormalizedParamsByPermission = (
 
 export type GetNormalizedParams = (action: ActionType, entity: StringOrStringList) => CanObjectOfConfig
 export type CanWrapperFunction = (entity: StringOrStringList) => boolean
+export type HasPermission = (actions: string[], entity: string, permissions: string[]) => boolean

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.util.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.util.ts
@@ -41,6 +41,22 @@ export const getNormalizedParamsByPermission: GetNormalizedParamsByPermission = 
   return normalizedParamsPayload
 }
 
-export const hasPermission: HasPermission = (action, entity, permissions: string[]) => action.some(actionItem => {
-  return permissions.includes(`${entity}.${actionItem}`)
-})
+/**
+ * Verifica se há permissão para uma determinada ação em uma entidade específica.
+ *
+ * @param action - Ações a serem verificadas.
+ * @param entity - Entidade na qual a ação será verificada.
+ * @param permissions - Lista de permissões disponíveis.
+ * @returns `true` se houver permissão para a ação na entidade, caso contrário `false`.
+ *
+ * @example
+ * ```typescript
+ * const permissions = ['user.create', 'user.delete', 'post.read'];
+ * const canCreateUser = hasPermission(['create'], 'user', permissions); // true
+ * const canUpdateUser = hasPermission(['update'], 'user', permissions); // false
+ * const canReadPost = hasPermission(['read'], 'post', permissions); // true
+ * ```
+ */
+export const hasPermission: HasPermission = (action, entity, permissions: string[]) => {
+  return action.some(actionItem => permissions.includes(`${entity}.${actionItem}`))
+}

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.util.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.util.ts
@@ -2,7 +2,8 @@ import {
   type CanByPermissionObjectOfConfig,
   type GetNormalizedParamsByPermission,
   type CanObjectOfConfig,
-  type GetNormalizedParams
+  type GetNormalizedParams,
+  type HasPermission
 } from './use-app-can-wrapper.type'
 
 export const getNormalizedParams: GetNormalizedParams = (action, entity) => {
@@ -39,3 +40,7 @@ export const getNormalizedParamsByPermission: GetNormalizedParamsByPermission = 
 
   return normalizedParamsPayload
 }
+
+export const hasPermission: HasPermission = (action, entity, permissions: string[]) => action.some(actionItem => {
+  return permissions.includes(`${entity}.${actionItem}`)
+})


### PR DESCRIPTION
## Não publicado
### Adicionado
`useAppCanWrapper`:
  - adicionado opção `action` nos métodos `can` e `canByPermission` para receber `string` ou `string[]` (array de string), anteriormente só recebia string, agora pode passar uma lista de ações.
  - modificado testes unitários para aceitar mudanças no `action`.
  
Closes #3 