### PR TITLE
Update canByPermission rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
+## 1.0.0-beta.11 - 10-04-2024
+### Modificado
+- `canByPermission`: modificado regra onde não adicionava permissão caso não encontrasse no `companyPermissions`, agora é sempre mergeado com `currentMainCompany`, fazendo com que se tem a permissão no currentMainCompany, ela seja enviada para todos company, mesmo que seja um company que não exista.
+
 ## 1.0.0-beta.10 - 28-01-2024
 ### Adicionado
 `useAppCanWrapper`: adicionado opção `action` nos métodos `can` e `canByPermission` para receber `string` ou `string[]` (array de string), anteriormente só recebia string, agora pode passar uma lista de ações.

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.test.ts
@@ -15,7 +15,7 @@ const storeList: AppCanWrapperStore[] = [
     isSuperuser: false,
     companyPermissions: {
       'company-uuid01': ['companies.list', 'companies.show'],
-      'company-uuid02': ['users.list', 'users.show', 'companies.delete', 'users.dashboard', 'settings.edit'],
+      'company-uuid02': ['users.list', 'users.show', 'companies.delete', 'users.dashboard', 'settings.edit', 'settings.delete'],
       'company-uuid03': ['companies.list', 'companies.show', 'companies.delete', 'users.edit'],
       'company-uuid04': ['settings.create', 'companies.show', 'companies.delete'],
       'company-uuid05': ['approvals.delete', 'companies.delete']
@@ -88,7 +88,7 @@ describe.each(storeList)('Permissionamento -> isSuperuser: $isSuperuser', (store
   })
 
   it(`canByPermission -> isSuperUser: ${isSuperuser}`, () => {
-    expect(canByPermission('users', { company: 'company1', action: 'dashboard' })).toBe(isSuperuser)
+    expect(canByPermission('users', { company: 'company1', action: 'dashboard' })).toBe(true)
     expect(canByPermission('users', { company: 'company-uuid01', action: 'edit' })).toBe(isSuperuser)
     expect(canByPermission('users', { company: 'company-uuid03', action: 'edit' })).toBe(true)
     expect(canByPermission('users', { company: 'company-uuid04', action: 'dashboard' })).toBe(true)
@@ -203,5 +203,25 @@ describe.each(storeList)('Permissionamento -> isSuperuser: $isSuperuser', (store
         company: 'company-uuid01'
       }
     })).toBe(true)
+  })
+
+  it(`canByPermission validar company somente pelo currentMainCompany -> isSuperUser: ${isSuperuser}`, () => {
+    expect(canByPermission('users', { company: 'company-random', action: 'dashboard' })).toBe(true)
+    expect(canByPermission('users', { company: 'company-random', action: 'create' })).toBe(isSuperuser)
+    expect(canByPermission('users', { company: 'company-random', action: ['create', 'dashboard'] })).toBe(true)
+    expect(canByPermission('companies', { company: 'company-random', action: 'xpto' })).toBe(isSuperuser)
+    expect(canByPermission('companies', { company: ['company-random', 'company-uuid01'], action: ['list'] })).toBe(true)
+
+    // show
+    expect(canShow('users', { company: 'company-random' })).toBe(true)
+    expect(canShow('companies', { company: 'company-random' })).toBe(isSuperuser)
+
+    // edit
+    expect(canEdit('companies', { company: 'company-random' })).toBe(isSuperuser)
+
+    // delete
+    expect(canDelete('settings', { company: 'company-random' })).toBe(true)
+    expect(canDelete('companies', { company: 'company-random' })).toBe(true)
+    expect(canDelete('users', { company: 'company-random' })).toBe(isSuperuser)
   })
 })

--- a/src/composables/app-can-wrapper/use-app-can-wrapper.ts
+++ b/src/composables/app-can-wrapper/use-app-can-wrapper.ts
@@ -149,8 +149,6 @@ export function useAppCanWrapper ({ store }: UseAppCanWrapperParam) {
       for (const companyItem of normalizedCompany) {
         const companyPermission = companyPermissions[companyItem]
 
-        if (!companyPermission) continue
-
         /**
          * mergeia as permissões da empresa mãe atual com as permissões da empresa atual
          *


### PR DESCRIPTION
## 1.0.0-beta.11 - 10-04-2024
### Modificado
- `canByPermission`: modificado regra onde não adicionava permissão caso não encontrasse no `companyPermissions`, agora é sempre mergeado com `currentMainCompany`, fazendo com que se tem a permissão no currentMainCompany, ela seja enviada para todos company, mesmo que seja um company que não exista.
